### PR TITLE
Add support for write all

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -8,6 +8,10 @@ if !exists("g:vroom_use_colors")
   let g:vroom_use_colors = 0
 endif
 
+if !exists("g:vroom_write_all")
+  let g:vroom_write_all = 0
+endif
+
 " Public: Run current test file, or last test run
 function vroom#RunTestFile()
   call s:RunTestFile()
@@ -50,7 +54,7 @@ endfunction
 
 " Internal: Runs the test for a given filename
 function s:RunTests(filename)
-  :w " Write the file
+  call s:WriteOrWriteAll()
   call s:CheckForGemfile()
   call s:SetColorFlag()
   " Run the right test for the given file
@@ -61,6 +65,15 @@ function s:RunTests(filename)
   elseif match(a:filename, "_test.rb") != -1
     exec ":!" . s:bundle_exec ."ruby -Itest " . a:filename . s:color_flag
   end
+endfunction
+
+" Internal: Write or write all files
+function s:WriteOrWriteAll()
+  if g:vroom_write_all
+    :wall
+  else
+    :w
+  endif
 endfunction
 
 " Internal: Checks for Gemfile, and sets s:bundle_exec as necessary

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -29,6 +29,13 @@ Map default keys to run tests
 Default: 1
 
 ===============================================================================
+g:vroom_write_all                               *vroom_write_all*
+
+Write all file before running tests
+
+Default: 0 (write the current file)
+
+===============================================================================
 <leader>r                                        *<leader>r*
 
 Mapped to :VroomRunTestFile


### PR DESCRIPTION
This commits adds support for write all through a global variable called
g:vroom_write_all, if it's equal to 0 (default) it will save only the
current file, if it's equal to 1, it will save all files prior to
running specs.
