### PR TITLE
Clear screen before running tests

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -8,6 +8,10 @@ if !exists("g:vroom_use_colors")
   let g:vroom_use_colors = 0
 endif
 
+if !exists("g:vroom_clear_screen")
+  let g:vroom_clear_screen = 1
+endif
+
 " Public: Run current test file, or last test run
 function vroom#RunTestFile()
   call s:RunTestFile()
@@ -51,6 +55,7 @@ endfunction
 " Internal: Runs the test for a given filename
 function s:RunTests(filename)
   :w " Write the file
+  call s:ClearScreen()
   call s:CheckForGemfile()
   call s:SetColorFlag()
   " Run the right test for the given file
@@ -61,6 +66,13 @@ function s:RunTests(filename)
   elseif match(a:filename, "_test.rb") != -1
     exec ":!" . s:bundle_exec ."ruby -Itest " . a:filename . s:color_flag
   end
+endfunction
+
+" Internal: Clear the screen prior to running specs
+function s:ClearScreen()
+  if g:vroom_clear_screen
+    :silent !clear
+  endif
 endfunction
 
 " Internal: Checks for Gemfile, and sets s:bundle_exec as necessary

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -29,6 +29,13 @@ Map default keys to run tests
 Default: 1
 
 ===============================================================================
+g:vroom_clear_screen                             *vroom_clear_screen*
+
+Clear the screen before running tests
+
+Default: 1
+
+===============================================================================
 <leader>r                                        *<leader>r*
 
 Mapped to :VroomRunTestFile


### PR DESCRIPTION
This feature is controller by the g:vroom_clear_screen setting, which is
on by default.
