### PR TITLE
Write all with clear screen support

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -12,6 +12,10 @@ if !exists("g:vroom_clear_screen")
   let g:vroom_clear_screen = 1
 endif
 
+if !exists("g:vroom_write_all")
+  let g:vroom_write_all = 0
+endif
+
 " Public: Run current test file, or last test run
 function vroom#RunTestFile()
   call s:RunTestFile()
@@ -54,8 +58,8 @@ endfunction
 
 " Internal: Runs the test for a given filename
 function s:RunTests(filename)
-  :w " Write the file
   call s:ClearScreen()
+  call s:WriteOrWriteAll()
   call s:CheckForGemfile()
   call s:SetColorFlag()
   " Run the right test for the given file
@@ -72,6 +76,15 @@ endfunction
 function s:ClearScreen()
   if g:vroom_clear_screen
     :silent !clear
+  endif
+endfunction
+
+" Internal: Write or write all files
+function s:WriteOrWriteAll()
+  if g:vroom_write_all
+    :wall
+  else
+    :w
   endif
 endfunction
 

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -36,6 +36,13 @@ Clear the screen before running tests
 Default: 1
 
 ===============================================================================
+g:vroom_write_all                               *vroom_write_all*
+
+Write all file before running tests
+
+Default: 0 (write the current file)
+
+===============================================================================
 <leader>r                                        *<leader>r*
 
 Mapped to :VroomRunTestFile


### PR DESCRIPTION
This pull request pulls both #1 and #2, opened it because there's a conflict between the two pull requests and clear screen must be called before saving the files so if the user chose not to enable write all support, he will be informed that there are some unsaved files. #1 and #2 are left open but pulling this one should close them

closes #1
closes #2
