### PR TITLE
Default colors on for terminal Vim, off for GUI

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -5,7 +5,7 @@ endif
 let g:loaded_vroom = 1
 
 if !exists("g:vroom_use_colors")
-  let g:vroom_use_colors = 0
+  let g:vroom_use_colors = !has('gui_running')
 endif
 
 if !exists("g:vroom_clear_screen")

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -19,7 +19,7 @@ g:vroom_use_colors                               *vroom_use_colors*
 
 Run tests with or without colors
 
-Default: 0
+Default: 0 if GUI is running, 1 otherwise
 
 ===============================================================================
 g:vroom_map_keys                                 *vroom_map_keys*


### PR DESCRIPTION
Since color codes FUBAR GUI Vim, but are nice in terminal. Smart defaults, yay!
