### PR TITLE
add support for binstubs (e.g., when using rbenv)

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -32,11 +32,13 @@ if !exists("g:vroom_use_bundle_exec")
   let g:vroom_use_bundle_exec = 1
 endif
 
-" If we are using binstubs, we usually don't want to bundle exec.
+" If we are using binstubs, we usually don't want to bundle exec.  Note that
+" this has to come before the g:vroom_use_binstubs variable is set below.
 if exists("g:vroom_use_binstubs")
   let g:vroom_use_bundle_exec = 0
 endif
 
+" Binstubs aren't used by default
 if !exists("g:vroom_use_binstubs")
   let g:vroom_use_binstubs = 0
 endif

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -80,6 +80,26 @@ g:vroom_detect_spec_helper                           *vroom_detect_spec_helper*
 g:vroom_use_vimux                                             *vroom_use_vimux*
                         Run tests using the vimux plugin
 
+g:vroom_use_bundle_exec                                 *vroom_use_bundle_exec*
+                        When appropriate (see |vroom_detect_spec_helper|) use
+                        `bundle exec` before test runner command.  If set to
+                        1, `bundle exec` is never used.
+                        Default: 0
+
+g:vroom_use_binstubs                                       *vroom_use_binstubs*
+                        If set to 1, lets Vroom know you are using binstubs.
+                        This means (a) the call to your test runner will be
+                        prefixed with your binstubs directory (see
+                        |vroom_binstubs_path|), and (b) `bundle exec` will
+                        never be called (see |vroom_use_bundle_exec|).
+                        Default: 0
+
+g:vroom_binstubs_path                                     *vroom_binstubs_path*
+                        If using binstubs, the directory where your binstubs
+                        are installed.  The forward slash gets added
+                        automatically and should not be included.
+                        Default: './bin'
+
 ===============================================================================
 LICENSE                                                         *vroom-license*
 


### PR DESCRIPTION
In order to allow this, I end up making a handful of changes.  The
s:bundle_exec variable becomes the s:test_runner_prefix variable, which
gets set in a function.  This simplifies a bit of logic and lets us set
the variable based on a few (sometimes independent) preferences: whether
to use `bundle exec` or not and whether to use binstubs (and where they
are located).  A few new variables must be added to make this work: by
default binstubs are turned off (though a path is set if you turn them
on), and bundle exec is turned on.

Note that this also adds an option that fixes issue #12.

Also note: this is kind of a big hunk of changes and I realize that (a) you might not want to add all these changes and (b) you might want them done differently.  If you need or want me to clean anything up or do anything differently, please let me know.

Thanks for Vroom.  I just started using it and I'm _really_ liking it.  Awesome work.
