### PR TITLE
Add custom runner

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -56,23 +56,18 @@ endif
 " Main functions {{{
 
 " Public: Run current test file, or last test run
-function vroom#RunTestFile()
-  call s:RunTestFile({})
-endfunction
-
-" Public: Run the nearest test in the current test file
-" Assumes your test framework supports filename:line# format
-function vroom#RunNearestTest()
-  call s:RunNearestTest({})
-endfunction
-
-" Public: Run current test file, or last test run with custom options.
 "
 " args     - options for running the tests:
 "            'runner': the test runner to use (e.g., 'm')
-"            'opts': any additional options (e.g., '--drb')
-function vroom#RunTestFileCustom(args)
-  call s:RunTestFile(a:args)
+"            'options': any additional options (e.g., '--drb')
+function vroom#RunTestFile(...)
+  if a:0
+    let opts = a:1
+  else
+    let opts = {}
+  endif
+
+  call s:RunTestFile(opts)
 endfunction
 
 " Public: Run the nearest test in the current test file
@@ -80,9 +75,15 @@ endfunction
 "
 " args     - options for running the tests:
 "            'runner': the test runner to use (e.g., 'm')
-"            'opts': any additional options (e.g., '--drb')
-function vroom#RunNearestTestCustom(args)
-  call s:RunNearestTest(a:args)
+"            'options': any additional options (e.g., '--drb')
+function vroom#RunNearestTest(...)
+  if a:0
+    let opts = a:1
+  else
+    let opts = {}
+  endif
+
+  call s:RunNearestTest(opts)
 endfunction
 
 " }}}
@@ -107,7 +108,7 @@ endfunction
 " number
 function s:RunNearestTest(args)
   let spec_line_number = ':' . line('.')
-  let updated_args = extend(a:args, {'line':spec_line_number })
+  let updated_args = s:Merge(a:args, {'line':spec_line_number})
 
   call s:RunTestFile(updated_args)
 endfunction
@@ -117,7 +118,7 @@ endfunction
 " filename - a filename.
 " args     - options for running the tests:
 "            'runner': the test runner to use (e.g., 'm')
-"            'opts': any additional options (e.g., '--drb')
+"            'options': any additional options (e.g., '--drb')
 "            'line_number': the line number of the test to run (e.g., ':4')
 function s:RunTests(filename, args)
   call s:PrepareToRunTests()
@@ -176,6 +177,20 @@ function s:WriteOrWriteAll()
   else
     :w
   endif
+endfunction
+
+" Internal: Merge a pair of dictionaries non-destructively.
+"
+" dictionary1 - the dictionary that is to be merged into.
+" dictionary2 - the dictionary that is to be merged in.
+"
+" Returns a dictionary.
+function s:Merge(dictionary1, dictionary2)
+  let dictionary = {}
+  call extend(dictionary, a:dictionary1)
+  call extend(dictionary, a:dictionary2)
+
+  return dictionary
 endfunction
 
 " }}}

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -37,9 +37,22 @@ COMMANDS                                                       *vroom-commands*
                         the last test file that was run.
 
 :VroomRunNearestTest                                      *VroomRunNearestTest*
-
                         Runs the nearest test in the current file if it's a
                         test. Otherwise, runs the last test that was run.
+                        
+                        NOTICE:
+                        Both of these commands can take pass a dictionary of
+                        arguments to this function.  The two recognized keys
+                        are 'runner' and 'options'.  Use 'runner' to specify the
+                        full command for an alternate runner.  Use 'options' for
+                        any command line switches you want to add.
+                        Examples:
+                        :call vroom#RunTestFile({'runner':'spin serve'})
+                        " calls `spin serve file-to-be-tested`
+                        :call vroom#RunTestFile({'options':'--drb'}) "
+                        " if called with rspec, calls
+                        " `bundle exec rspec --drb file-to-be-tested`
+                        " (for if you are using Spork)
 
 -------------------------------------------------------------------------------
 KEY MAPPINGS                                               *vroom-key-mappings*


### PR DESCRIPTION
This is a revision of my previous stab at making custom runners easy. :)  This fixes the issue I was having where the line number was getting set permanently and cleans up the history just a bit.  So I'm happy with this version.

Here's the pull request from before.  I'll add a brief note at the end with some updates.

This is a pretty serious reworking of some of the underpinnings to give some new functionality, but nothing from the outside has to change.  You can see the code here, so I won't say too much about it.  But here's an overview:

I rewrote the two main functions (vroom#RunTestFile() and vroom#RunNearestTest()) so that they take an optional argument, a dictionary.  That dictionary can have two keys: 'runner' and 'options'.  This lets me define a mapping like so:

```
nmap <leader>td :call vroom#RunTestFile({'runner':'spin serve'})
```

or, if I'd rather use Spork:

```
nmap <leader>td :call vroom#RunTestFile(('options':'--drb'})
```

You could also use a better Test::Unit runner:

```
nmap <leader>tD :call vroom#RunNearestTest(('runner':'testrbl'})
```

The rewritten functions are flexible enough to keep from changing the current api while still giving the flexibility that I wanted.

I moved a decent bit of stuff around, but I didn't mess with any of the option checking.  So hopefully nothing is broken. :) I tested manually as much as I could, but I'm sure I didn't get everything.
## Update

Since I changed the internal methods a good deal, I ended up having to add the custom Rspec variable from the last merge via a merge conflict commit (well, a rebase, so you can't see it!).  That should be right in this version, though I didn't test it.
## Questions:
1. One concern here is with the color flag.  I don't include it in the custom runner option, since I assume you might have some runners that don't use that flag at all.  But maybe it should be in there?
2. In this same branch I made some changes to the default behavior for calling tests (using `ruby`).  I don't think you want to use the bundle prefix there (you definitely don't want to use your binstub prefix, else you'd call `./bin/ruby`, which won't exist), and I don't think you want to use the color flag.  Maybe you want to call `bundle exec`? I don't use `bundle exec` so I don't know if this is the proper behavior or not.  The question: should I leave this change in here, or was it misguided?
