### PR TITLE
Configurable Test::Unit command

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -52,6 +52,10 @@ if !exists("g:vroom_binstubs_path")
   let g:vroom_binstubs_path = './bin'
 endif
 
+if !exists("g:vroom_test_unit_command")
+  let g:vroom_test_unit_command = 'ruby -Itest '
+endif
+
 " }}}
 " Main functions {{{
 
@@ -137,7 +141,7 @@ function s:DetermineRunner(filename)
   elseif match(a:filename, '\.feature') != -1
     return s:Run(s:test_runner_prefix . g:vroom_cucumber_path . s:color_flag
   elseif match(a:filename, "_test.rb") != -1
-    return "ruby -Itest"
+    return s:test_runner_prefix . g:vroom_test_unit_command
   end
 endfunction
 

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -113,10 +113,15 @@ g:vroom_binstubs_path                                     *vroom_binstubs_path*
                         automatically and should not be included.
                         Default: './bin'
 
-g:vroom_spec_command                                      *vroom_spec_command*
+g:vroom_spec_command                                       *vroom_spec_command*
                         This lets you specify the command that runs your
                         specs, e.g. for rspec 1.x, you can use 'spec '.
                         Default: 'rspec '
+
+g:vroom_test_unit_command                             *vroom_test_unit_command*
+                        This lets you specify the command that runs your
+                        tests, e.g. you can use 'm ' or 'testrbl '.
+                        Default: 'ruby -Itest '
 
 ===============================================================================
 LICENSE                                                         *vroom-license*


### PR DESCRIPTION
While RSpec and Cucumber have global variables that can be set to override their shell command, the Ruby default does not. This commit adds support for `g:vroom_test_unit_command`, which defaults to `ruby -Itest` (thus implementing the current behavior).
