### PR TITLE
clear screen as part of the command

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -196,12 +196,11 @@ function s:Run(cmd)
   end
 endfunction
 
-" Internal: Clear the screen prior to running specs
+" Internal: Clear the screen prior to running specs for vimux
+" Otherwise, prefix the command with a clear.
 function s:ClearScreen()
   if g:vroom_use_vimux
     call VimuxRunCommand("clear")
-  else
-    :silent !clear
   endif
 endfunction
 
@@ -238,6 +237,7 @@ function s:SetTestRunnerPrefix(filename)
   call s:IsUsingBundleExec(a:filename)
   call s:IsUsingBinstubs()
   call s:IsUsingSpring()
+  call s:IsClearScreenEnabled()
 endfunction
 
 " Internal: Check for .zeus.sock and use zeus instead of bundler
@@ -288,6 +288,14 @@ endfunction
 function s:IsUsingSpring()
   if g:vroom_use_spring
     let s:test_runner_prefix = "spring "
+  endif
+endfunction
+
+" Internal: Check to see if we should clear the screen and prefixes
+"           s:test_runner_prefix as neessary
+function s:IsClearScreenEnabled()
+  if g:vroom_clear_screen && !g:vroom_use_vimux
+    let s:test_runner_prefix = "clear; " . s:test_runner_prefix
   endif
 endfunction
 


### PR DESCRIPTION
This is a little faster and it also deals with race conditions when
`&t_te` and `t_ti` are doing things like enabling/disabling focus tracking
with vitality.vim.

I didn't test with vimux, but I don't see any reason it wouldn't work. It also simplifies the vimux code.
