### PR TITLE
Support running last test

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -110,6 +110,15 @@ function vroom#RunNearestTest(...)
   call s:RunNearestTest(opts)
 endfunction
 
+" Public: Run the last executed test.
+function vroom#RunLastTest()
+  if exists('g:vroom_last_cmd')
+    call s:Run(g:vroom_last_cmd)
+  else
+    echo 'No test was run.'
+  endif
+endfunction
+
 " }}}
 " Internal helper functions {{{
 
@@ -191,6 +200,7 @@ endfunction
 
 " Internal: Runs a command though vim or vmux
 function s:Run(cmd)
+  let g:vroom_last_cmd = a:cmd
   if g:vroom_use_vimux
     call VimuxRunCommand(a:cmd)
   elseif g:vroom_use_dispatch && exists(':Dispatch')

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -54,12 +54,16 @@ COMMANDS                                                       *vroom-commands*
                         " `bundle exec rspec --drb file-to-be-tested`
                         " (for if you are using Spork)
 
+:VroomRunLastTest                                            *VroomRunLastTest*
+                        Runs the last executed test. Can be executed from any
+                        buffer, window or tab.
+
 -------------------------------------------------------------------------------
 KEY MAPPINGS                                               *vroom-key-mappings*
 
-By default vroom maps <Leader>r to |VroomRunTestFile| and <Leader>R to
-|VroomRunNearestTest|. This can be turned off by simply putting `let
-g:vroom_map_keys = 0` in your vimrc.
+By default vroom maps <Leader>r to |VroomRunTestFile|, <Leader>R to
+|VroomRunNearestTest| and <Leader>l to VroomRunLastTest. This can be turned off
+by simply putting `let g:vroom_map_keys = 0` in your vimrc.
 
 ===============================================================================
 CUSTOMIZATION                                             *vroom-customization*

--- a/plugin/vroom.vim
+++ b/plugin/vroom.vim
@@ -7,6 +7,7 @@
 
 command! -nargs=0 VroomRunTestFile call vroom#RunTestFile()
 command! -nargs=0 VroomRunNearestTest call vroom#RunNearestTest()
+command! VroomRunLastTest call vroom#RunLastTest()
 
 if !exists("g:vroom_map_keys")
   let g:vroom_map_keys = 1
@@ -15,4 +16,5 @@ endif
 if g:vroom_map_keys
   silent! map <unique> <Leader>r :VroomRunTestFile<CR>
   silent! map <unique> <Leader>R :VroomRunNearestTest<CR>
+  silent! map <unique> <Leader>l :VroomRunLastTest<CR>
 endif


### PR DESCRIPTION
Adds new command which runs previously run test so it's no longer necessary to switch to test file buffer. By default, it is mapped to `<Leader>l`.
