### PR TITLE
call SetColorFlag even with Zeus present

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -198,7 +198,6 @@ function s:PrepareToRunTests(filename)
   call s:WriteOrWriteAll()
   call s:SetTestRunnerPrefix(a:filename)
   call s:SetColorFlag()
-  endif
 endfunction
 
 " Internal: Runs a command though vim or vmux

--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -197,10 +197,7 @@ function s:PrepareToRunTests(filename)
   endif
   call s:WriteOrWriteAll()
   call s:SetTestRunnerPrefix(a:filename)
-  if s:usingZeus()
-    let s:color_flag = ""
-  else
-    call s:SetColorFlag()
+  call s:SetColorFlag()
   endif
 endfunction
 


### PR DESCRIPTION
When Zeus was present the color flag option was set empty in a compulsory way... this messed the output of command if you have a .rspec file with "--color" in it.

I have fixed it hoping I don't break anything, at least it works fine for me.