### PR TITLE
Add regex for default configuration when creating a new gem

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -138,7 +138,7 @@ endfunction
 " next time the function is called in a non-test file, it runs the last test
 function s:RunTestFile(args)
   " Run the tests for the previously-marked file.
-  let in_test_file = match(expand("%"), '\(\.feature\|_spec\.rb\|_test\.exs\|_test\.rb\|_spec\.js.*\)$') != -1
+  let in_test_file = match(expand("%"), '\(\/test_.*\.rb\)\|\(\.feature\|_spec\.rb\|_test\.exs\|_test\.rb\|_spec\.js.*\)$') != -1
 
   if in_test_file
     call s:SetTestFile()
@@ -199,6 +199,8 @@ function s:DetermineRunner(filename)
     return s:test_runner_prefix . g:vroom_spec_command . s:color_flag
   elseif match(a:filename, '\.feature$') != -1
     return s:test_runner_prefix . g:vroom_cucumber_path . g:vroom_cucumber_options . s:color_flag
+  elseif match(a:filename, '\/test_.*\.rb$') != -1
+    return s:test_runner_prefix . g:vroom_test_unit_command
   elseif match(a:filename, '_test\.rb$') != -1
     return s:test_runner_prefix . g:vroom_test_unit_command
   elseif match(a:filename, '_test\.exs$') != -1


### PR DESCRIPTION
When you create a gem, `minitest` is the default test framework, and files are called:

    test/test_hola.rb

Since that is a valid approach when naming files to test with minitest, I thought it could be useful to be added. 

Note: the "nearest test" feature doesn't work, because the "test_feature.rb:3", doesn't work in plain ruby projects (`no such file or directory`).