### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -41,7 +41,7 @@ COMMANDS                                                       *vroom-commands*
                         test. Otherwise, runs the last test that was run.
 
                         NOTICE:
-                        Both of these commands can take pass a dictionary of
+                        Both of these commands can take a dictionary of
                         arguments to this function.  The two recognized keys
                         are 'runner' and 'options'.  Use 'runner' to specify the
                         full command for an alternate runner.  Use 'options' for


### PR DESCRIPTION
Fixing a typo in the documentation--should either be "take a dictionary" or "be passed a dictionary"