### PR TITLE
Added support to execute in NeoVim :terminal

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -61,6 +61,10 @@ if !exists("g:vroom_use_vimshell")
   let g:vroom_use_vimshell = 0
 endif
 
+if !exists("g:vroom_use_terminal")
+  let g:vroom_use_terminal = 0
+endif
+
 if !exists("g:vroom_use_bundle_exec")
   let g:vroom_use_bundle_exec = 1
 endif
@@ -235,6 +239,8 @@ function s:Run(cmd)
   let g:vroom_last_cmd = a:cmd
   if g:vroom_use_vimux
     call VimuxRunCommand(a:cmd)
+  elseif g:vroom_use_terminal
+    call s:RunNeoTerminal(a:cmd)
   elseif g:vroom_use_vimshell
     exec "VimShellExecute " . a:cmd
   elseif g:vroom_use_dispatch && exists(':Dispatch')
@@ -242,6 +248,11 @@ function s:Run(cmd)
   else
     exec ":!" . a:cmd
   end
+endfunction
+
+function s:RunNeoTerminal(cmd)
+  let height=winheight(0) * 1/4
+  exec ":belowright " . height . "split | :terminal " . a:cmd
 endfunction
 
 " Internal: Clear the screen prior to running specs for vimux

--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -253,6 +253,7 @@ endfunction
 function s:RunNeoTerminal(cmd)
   let height=winheight(0) * 1/4
   exec ":belowright " . height . "split | :terminal " . a:cmd
+  exec ":stopinsert"
 endfunction
 
 " Internal: Clear the screen prior to running specs for vimux

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -98,13 +98,17 @@ g:vroom_detect_spec_helper                           *vroom_detect_spec_helper*
                         requires 'spec_helper'
                         Default: 0
 
-g:vroom_mix_test_command                                   *vroom_mix_test_command*
+g:vroom_mix_test_command                               *vroom_mix_test_command*
                         If set, the path for the executable
                         used to run ExUnit test files.
                         Default: 'mix test '
 
 g:vroom_use_vimux                                             *vroom_use_vimux*
                         Run tests using the vimux plugin
+
+g:vroom_use_terminal                                       *vroom_use_terminal*
+                        Run tests using Neovim's embedded terminal emulator
+                        Default: 0
 
 g:vroom_use_spring                                           *vroom_use_spring*
                         This lets you specify to use spring.


### PR DESCRIPTION
NeoVim has it's own terminal emulator without requiring additional vim-scripts, see: https://www.youtube.com/watch?v=xZbMVj9XSUo

Fix #72 