### PR TITLE
Update vundle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Check out [vundle](https://github.com/gmarik/vundle) or
 
 Add the following to your `.vimrc` after vundle setup:
 
-    Bundle 'skalnik/vim-vroom'
+    Plugin 'skalnik/vim-vroom'
 
-and remember to run `:BundleInstall`.
+and remember to run `:PluginInstall`.
 
 ### pathogen
 


### PR DESCRIPTION
See https://unix.stackexchange.com/questions/171233/plugininstall-vs-bundleinstall-command-in-vundle

"Commands with the word Plugin should be preferred.

In past plugins used to be called "bundles", therefore all associated commands had "bundle" in the name. In the beginning of 2014 there was a global rename (see this commit). The old "bundle" commands were left only for compatibility reasons."