### PR TITLE
Add g:vroom_command_prefix configuration

### DIFF
--- a/autoload/vroom.vim
+++ b/autoload/vroom.vim
@@ -84,6 +84,10 @@ if !exists("g:vroom_binstubs_path")
   let g:vroom_binstubs_path = './bin'
 endif
 
+if !exists("g:vroom_command_prefix")
+  let g:vroom_command_prefix = ''
+endif
+
 if !exists("g:vroom_test_unit_command")
   let g:vroom_test_unit_command = 'ruby -Itest '
 endif
@@ -285,6 +289,7 @@ function s:SetTestRunnerPrefix(filename)
   call s:IsUsingBundleExec(a:filename)
   call s:IsUsingBinstubs()
   call s:IsUsingSpring()
+  call s:PrependCommandPrefix()
   call s:IsClearScreenEnabled()
 endfunction
 
@@ -337,6 +342,11 @@ function s:IsUsingSpring()
   if g:vroom_use_spring
     let s:test_runner_prefix = "spring "
   endif
+endfunction
+
+" Internal: Prepend g:vroom_command_prefix (default: '') to s:test_runner_prefix
+function s:PrependCommandPrefix()
+  let s:test_runner_prefix = g:vroom_command_prefix . " " . s:test_runner_prefix
 endfunction
 
 " Internal: Check to see if we should clear the screen and prefixes

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -142,6 +142,10 @@ g:vroom_command_prefix                                   *vroom_command_prefix*
                         This lets you specify a prefix to all commands that
                         vroom runs, such as a script that redirects commands
                         to a Docker container or remote machine via ssh.
+                        For example, exec vroom commands in a Docker container
+                        for a specific project:
+                        `au BufReadPost */my-docker-project/* \`
+                        `let g:vroom_command_prefix='docker-compose exec cntnr'`
                         Default: ''
 
 g:vroom_spec_command                                       *vroom_spec_command*

--- a/doc/vroom.txt
+++ b/doc/vroom.txt
@@ -138,6 +138,12 @@ g:vroom_binstubs_path                                     *vroom_binstubs_path*
                         automatically and should not be included.
                         Default: './bin'
 
+g:vroom_command_prefix                                   *vroom_command_prefix*
+                        This lets you specify a prefix to all commands that
+                        vroom runs, such as a script that redirects commands
+                        to a Docker container or remote machine via ssh.
+                        Default: ''
+
 g:vroom_spec_command                                       *vroom_spec_command*
                         This lets you specify the command that runs your
                         specs, e.g. for rspec 1.x, you can use 'spec '.


### PR DESCRIPTION
This PR adds support to configure a prefix to all commands.

In my case, all development is done in Docker containers; I can't run the tests locally. I set `g:vroom_command_prefix` to:

```vim
let g:vroom_command_prefix='docker-compose exec my-container-name'
```

I'd be happy to update this PR to address any feedback you have. Thanks!